### PR TITLE
feat(types): add vault entry type detection module

### DIFF
--- a/src/vaultctl/types.py
+++ b/src/vaultctl/types.py
@@ -1,0 +1,40 @@
+"""Vault entry type detection and field access utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_TYPE = "secretText"
+KNOWN_TYPES = frozenset({"secretText", "usernamePassword", "sshKey", "certificate"})
+
+
+def detect_entry_type(value: Any) -> str:
+    """Detect the type of a vault entry from its value.
+
+    Returns the ``type`` field of a dict entry, or ``"secretText"`` for
+    plain string values and dicts without an explicit type.
+    """
+    if isinstance(value, dict):
+        return str(value.get("type", DEFAULT_TYPE))
+    return DEFAULT_TYPE
+
+
+def get_entry_fields(value: Any) -> list[str]:
+    """Return sorted field names of a structured entry (excluding 'type')."""
+    if isinstance(value, dict):
+        return sorted(k for k in value if k != "type")
+    return []
+
+
+def get_field_value(value: Any, field: str) -> Any:
+    """Access a specific field within a structured vault entry.
+
+    Raises ``KeyError`` when *value* is not a dict or *field* is missing.
+    """
+    if not isinstance(value, dict):
+        msg = f"Entry is not structured (plain string), cannot access field '{field}'"
+        raise KeyError(msg)
+    if field not in value:
+        msg = f"Field '{field}' not found"
+        raise KeyError(msg)
+    return value[field]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,61 @@
+"""Tests for vault entry type detection utilities."""
+
+from __future__ import annotations
+
+import pytest
+from vaultctl.types import (
+    DEFAULT_TYPE,
+    detect_entry_type,
+    get_entry_fields,
+    get_field_value,
+)
+
+
+class TestDetectEntryType:
+    def test_string_value(self):
+        assert detect_entry_type("some-password") == "secretText"
+
+    def test_dict_without_type(self):
+        assert detect_entry_type({"username": "u", "password": "p"}) == "secretText"
+
+    def test_dict_with_type(self):
+        val = {"type": "usernamePassword", "username": "u", "password": "p"}
+        assert detect_entry_type(val) == "usernamePassword"
+
+    def test_dict_with_custom_type(self):
+        assert detect_entry_type({"type": "custom"}) == "custom"
+
+    def test_none_value(self):
+        assert detect_entry_type(None) == DEFAULT_TYPE
+
+    def test_int_value(self):
+        assert detect_entry_type(42) == DEFAULT_TYPE
+
+
+class TestGetEntryFields:
+    def test_string_value(self):
+        assert get_entry_fields("secret") == []
+
+    def test_dict_excludes_type(self):
+        val = {"type": "usernamePassword", "username": "u", "password": "p"}
+        assert get_entry_fields(val) == ["password", "username"]
+
+    def test_dict_without_type(self):
+        assert get_entry_fields({"a": 1, "b": 2}) == ["a", "b"]
+
+    def test_empty_dict(self):
+        assert get_entry_fields({}) == []
+
+
+class TestGetFieldValue:
+    def test_valid_field(self):
+        val = {"type": "usernamePassword", "username": "u", "password": "p"}
+        assert get_field_value(val, "password") == "p"
+
+    def test_missing_field(self):
+        with pytest.raises(KeyError, match="not found"):
+            get_field_value({"username": "u"}, "password")
+
+    def test_string_raises(self):
+        with pytest.raises(KeyError, match="not structured"):
+            get_field_value("plain-secret", "field")


### PR DESCRIPTION
## Summary
- Add `src/vaultctl/types.py` with utilities for detecting and accessing structured vault entry types (e.g. `usernamePassword`, `sshKey`)
- Add `tests/test_types.py` with 13 tests covering all type detection and field access functions
- Step 1 of #14 (structured vault data types)

Closes #14

## Test plan
- [x] `uv run pytest tests/test_types.py` — 13 tests pass
- [x] `uv run mypy --strict src/vaultctl/types.py` — clean
- [x] `uv run ruff check src/vaultctl/types.py` — clean