### PR TITLE
feat(keys): add entry_type field to KeyInfo dataclass

### DIFF
--- a/src/vaultctl/keys.py
+++ b/src/vaultctl/keys.py
@@ -21,6 +21,7 @@ class KeyInfo:
     rotate_cmd: str = ""
     ui_manageable: bool = False
     expires: str = ""
+    entry_type: str = ""
 
 
 @dataclass
@@ -58,6 +59,7 @@ def get_key_info(keys: dict[str, Any], key: str) -> KeyInfo | None:
         rotate_cmd=meta.get("rotate_cmd", ""),
         ui_manageable=meta.get("ui_manageable", False),
         expires=meta.get("expires", ""),
+        entry_type=meta.get("type", ""),
     )
 
 

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -102,3 +102,22 @@ def test_check_expiry_no_expires():
     keys = {"plain_key": {"description": "no expiry"}}
     warnings = check_expiry(keys)
     assert warnings == []
+
+
+def test_get_key_info_entry_type():
+    keys = {"db_creds": {"description": "DB credentials", "type": "usernamePassword"}}
+    info = get_key_info(keys, "db_creds")
+    assert info is not None
+    assert info.entry_type == "usernamePassword"
+
+
+def test_get_key_info_entry_type_default():
+    keys = {"plain": {"description": "A plain secret"}}
+    info = get_key_info(keys, "plain")
+    assert info is not None
+    assert info.entry_type == ""
+
+
+def test_get_key_info_entry_type_empty():
+    info = get_key_info({}, "missing")
+    assert info is None


### PR DESCRIPTION
## Summary
- Add `entry_type` field to `KeyInfo` dataclass, populated from `type` metadata in vault-keys.yml
- Enables tracking structured entry types (e.g. `usernamePassword`, `sshKey`) in key metadata
- Step 2 of #14 (structured vault data types)

## Test plan
- [x] 3 new tests: type present, type default (empty), missing key
- [x] All 15 `test_keys.py` tests pass
- [x] `mypy --strict` clean
- [x] `ruff check` clean