### PR TITLE
ci(release): use RELEASE_TOKEN for semantic-release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -43,7 +43,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v9.15.2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
           build: false
 
       # PyPI publishing disabled - using GitHub releases only
@@ -57,5 +57,5 @@ jobs:
         uses: python-semantic-release/publish-action@v9.15.2
         if: steps.release.outputs.released == 'true'
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.RELEASE_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with `RELEASE_TOKEN` (PAT) in release workflow
- `GITHUB_TOKEN` cannot push to protected branches, a PAT with admin rights can

## Test plan
- [x] Merge this PR, then verify the release workflow succeeds on the next `feat:` or `fix:` merge