### PR TITLE
feat(cli): display structured vault entry types

### DIFF
--- a/src/vaultctl/cli.py
+++ b/src/vaultctl/cli.py
@@ -18,6 +18,7 @@ from .keys import (
     update_key_metadata,
 )
 from .password import resolve_password
+from .types import detect_entry_type, get_entry_fields, get_field_value
 from .vault import VaultError, decrypt_vault, edit_vault, encrypt_vault
 from .yaml_util import dump_yaml
 
@@ -124,16 +125,19 @@ def list_cmd(vctx: VaultContext) -> None:
     for key in sorted(data.keys()):
         info = get_key_info(keys_meta, key)
         desc = info.description if info else ""
+        entry_type = detect_entry_type(data[key])
+        type_tag = f"[{entry_type}] " if entry_type != "secretText" else ""
         if desc:
-            click.echo(f"  {key:<40}  {desc}")
+            click.echo(f"  {key:<40}  {type_tag}{desc}")
         else:
-            click.echo(f"  {key:<40}  (no description)")
+            click.echo(f"  {key:<40}  {type_tag}(no description)")
 
 
 @main.command()
 @click.argument("key")
+@click.option("--field", default=None, help="Access a specific field of a structured entry.")
 @pass_ctx
-def get(vctx: VaultContext, key: str) -> None:
+def get(vctx: VaultContext, key: str, field: str | None) -> None:
     """Show the value of a vault key."""
     try:
         data = decrypt_vault(vctx.config.vault_file, vctx.password)
@@ -146,7 +150,22 @@ def get(vctx: VaultContext, key: str) -> None:
         sys.exit(1)
 
     value = data[key]
-    click.echo(value, nl=not isinstance(value, str) or not value.endswith("\n"))
+
+    if field:
+        try:
+            click.echo(get_field_value(value, field))
+        except KeyError as exc:
+            click.echo(f"Error: {exc}", err=True)
+            sys.exit(1)
+        return
+
+    entry_type = detect_entry_type(value)
+    if isinstance(value, dict):
+        click.echo(f"Type: {entry_type}")
+        for f in get_entry_fields(value):
+            click.echo(f"  {f}: {value[f]}")
+    else:
+        click.echo(value, nl=not isinstance(value, str) or not value.endswith("\n"))
 
 
 @main.command()
@@ -265,6 +284,8 @@ def describe(vctx: VaultContext, key: str) -> None:
         sys.exit(1)
 
     click.echo(f"Key:          {info.name}")
+    if info.entry_type:
+        click.echo(f"Type:         {info.entry_type}")
     click.echo(f"Description:  {info.description or '—'}")
     click.echo(f"Rotation:     {info.rotate or '—'}")
     if info.expires:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,11 @@ def vault_file(tmp_path):
         "another_key": "another_value",
         "restore_key": "current_value",
         "restore_key_previous": "old_value",
+        "db_creds": {
+            "type": "usernamePassword",
+            "username": "admin",
+            "password": "s3cret",
+        },
     }
     plain = tmp_path / "vault-plain.yml"
     encrypted = tmp_path / "vault.yml"
@@ -96,6 +101,12 @@ def keys_file(tmp_path):
                 "description": "Key already expired",
                 "rotate": "365d",
                 "expires": "2026-01-01",
+            },
+            "db_creds": {
+                "description": "Database credentials",
+                "type": "usernamePassword",
+                "rotate": "90d",
+                "consumers": ["app01"],
             },
         }
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,6 +166,48 @@ def test_set_with_expires(runner, cli_env):
     assert "2026-12-31" in result.output
 
 
+def test_get_structured_entry(runner, cli_env):
+    result = runner.invoke(main, ["get", "db_creds"])
+    assert result.exit_code == 0
+    assert "Type: usernamePassword" in result.output
+    assert "username: admin" in result.output
+    assert "password: s3cret" in result.output
+
+
+def test_get_structured_field(runner, cli_env):
+    result = runner.invoke(main, ["get", "db_creds", "--field", "username"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "admin"
+
+
+def test_get_structured_field_missing(runner, cli_env):
+    result = runner.invoke(main, ["get", "db_creds", "--field", "nonexistent"])
+    assert result.exit_code == 1
+    assert "not found" in result.output
+
+
+def test_get_field_on_plain_string(runner, cli_env):
+    result = runner.invoke(main, ["get", "test_key", "--field", "username"])
+    assert result.exit_code == 1
+    assert "not structured" in result.output
+
+
+def test_list_shows_type_tag(runner, cli_env):
+    result = runner.invoke(main, ["list"])
+    assert result.exit_code == 0
+    assert "[usernamePassword]" in result.output
+    # Plain string keys should NOT have a type tag
+    assert "[secretText]" not in result.output
+
+
+def test_describe_structured_entry(runner, cli_env):
+    result = runner.invoke(main, ["describe", "db_creds"])
+    assert result.exit_code == 0
+    assert "Type:" in result.output
+    assert "usernamePassword" in result.output
+    assert "Database credentials" in result.output
+
+
 def test_version(runner):
     result = runner.invoke(main, ["--version"])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- `get`: Shows type + fields for structured entries (dicts), add `--field` flag for direct field access
- `list`: Shows `[usernamePassword]` type tag for non-secretText entries
- `describe`: Shows `Type:` line when `entry_type` is set in metadata
- Test fixtures extended with structured `db_creds` entry
- 7 new integration tests

Closes #14

## Test plan
- [x] `test_get_structured_entry` — dict entry shows type + fields
- [x] `test_get_structured_field` — `--field username` returns single value
- [x] `test_get_structured_field_missing` — missing field exits 1
- [x] `test_get_field_on_plain_string` — `--field` on string exits 1
- [x] `test_list_shows_type_tag` — `[usernamePassword]` shown, `[secretText]` hidden
- [x] `test_describe_structured_entry` — Type line in describe output
- [x] All 51 tests pass, mypy strict clean, ruff clean