### PR TITLE
docs(readme): document required external binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ uv sync && uv run vaultctl --help
 ```
 </details>
 
+### Required external tools
+
+vaultctl shells out to external binaries that must be installed separately:
+
+- **`ansible-vault`** — handles the actual encryption/decryption.
+  Install via your distro package manager or `pip install ansible-core`.
+- **`cue`** *(optional, for schema validation — see [#34](https://github.com/cdds-ab/vaultctl/issues/34))* —
+  enables future `vaultctl validate` and schema-checked imports.
+  Install: <https://cuelang.org/docs/install/>.
+  vaultctl gracefully skips schema features when `cue` is not on `$PATH`.
+
 ## Quickstart: New Vault
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a "Required external tools" subsection to the README's Install section, listing the external binaries vaultctl shells out to.

**What changes:**
- Documents `ansible-vault` as a hard dependency (previously implicit — users had to discover this from error messages or the source).
- Pre-announces `cue` as an optional dependency for the upcoming schema-validation feature (#34), with a clear note that vaultctl will gracefully skip schema features when `cue` is missing.

**Why now:**
The `ansible-vault` documentation gap has existed since the project was extracted from the customer-specific tooling. We close it on the occasion of #34, which adds a second external binary (`cue`) and forced us to articulate the dependency model. Documenting both at once keeps the README consistent and avoids a second touch later.

**Why this approach:**
External binaries (subprocess) instead of native Python bindings, mirroring the existing `ansible-vault` pattern. Rationale for `cue` specifically: no production-ready native Python binding for CUE exists as of April 2026 (`pycue` alpha/inactive, official `cue-py` still in development). Subprocess is the realistic state of the art and keeps vaultctl free of CFFI/CGO complexity.

Closes #35.
Refs #34.

## Test plan

- [x] README diff visually reviewed — section renders correctly under "## Install"
- [x] Cross-references (#34) link to the right issue
- [ ] CI green (lint, test, security, build)