### PR TITLE
feat(config)!: move config into .vaultctl/ directory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ uv build
 src/vaultctl/
 ├── __init__.py        # Version
 ├── cli.py             # Click CLI with all subcommands
-├── config.py          # .vaultctl.yml discovery + loading
+├── config.py          # .vaultctl/config.yml discovery + loading
 ├── password.py        # Password fallback chain (env -> file -> cmd)
 ├── vault.py           # ansible-vault subprocess wrapper
 ├── keys.py            # vault-keys.yml metadata CRUD + expiry check
@@ -81,14 +81,15 @@ src/vaultctl/
 - The Python API of ansible is unstable and poorly documented
 - Subprocess approach is simpler and more robust
 
-**3. Configuration discovery (.vaultctl.yml):**
+**3. Configuration discovery (`.vaultctl/config.yml`):**
 - Environment variable (`$VAULTCTL_CONFIG`)
-- Upward search from CWD to git root
+- Upward search from CWD to git root for `.vaultctl/config.yml`
 - User-global fallback (`~/.config/vaultctl/config.yml`)
-- All paths resolved relative to config file directory
+- Vault and keys paths resolve relative to the project root (parent of `.vaultctl/`),
+  not inside `.vaultctl/` — keeps secrets at their natural Ansible location
 
 **4. Password resolution chain:**
-- Configurable via `.vaultctl.yml` `password:` section
+- Configurable via `.vaultctl/config.yml` `password:` section
 - Environment variable -> File -> Command (subprocess)
 - Clear error messages listing tried sources
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ All mutating commands support `--force` to skip confirmation prompts.
 
 ## Configuration
 
-vaultctl looks for `.vaultctl.yml` in: `$VAULTCTL_CONFIG` → current directory upwards to git root → `~/.config/vaultctl/config.yml`.
+vaultctl looks for `.vaultctl/config.yml` in: `$VAULTCTL_CONFIG` → current directory upwards to git root → `~/.config/vaultctl/config.yml`.
 
 ```yaml
+# .vaultctl/config.yml
 vault_file: inventory/group_vars/all/vault.yml
 keys_file: inventory/group_vars/all/vault-keys.yml
 
@@ -81,7 +82,7 @@ password:
   cmd: pass show project/vault # then command
 ```
 
-All paths resolve relative to the config file.
+Paths resolve relative to the project root (the parent of `.vaultctl/`), so vault and keys files live where Ansible expects them — typically next to your inventory data, not inside `.vaultctl/` itself.
 
 ## Key Metadata
 
@@ -125,7 +126,7 @@ Downgrades are prevented. Updates without published checksums are refused.
 
 **"Decryption failed (no vault secrets were found that could decrypt)"**
 
-vaultctl cannot find or resolve the vault password. Check your `.vaultctl.yml`:
+vaultctl cannot find or resolve the vault password. Check your `.vaultctl/config.yml`:
 
 ```yaml
 password:
@@ -138,11 +139,11 @@ At least one source must be configured. The chain is tried top to bottom — fir
 
 **"No config file found"**
 
-vaultctl searches for `.vaultctl.yml` upwards from the current directory. Run `vaultctl init` to create one, or set `VAULTCTL_CONFIG=/path/to/.vaultctl.yml`.
+vaultctl searches for `.vaultctl/config.yml` upwards from the current directory. Run `vaultctl init` to create one, or set `VAULTCTL_CONFIG=/path/to/config.yml`.
 
 **`vaultctl init` overwrites my password config**
 
-`init` creates a fresh `.vaultctl.yml` with defaults. If you re-run `init` in a directory that already has a config, the password section resets. Edit `.vaultctl.yml` manually after init to add your password source.
+`init` creates a fresh `.vaultctl/config.yml` with defaults. If you re-run `init` in a directory that already has a config, the password section resets. Edit `.vaultctl/config.yml` manually after init to add your password source.
 
 **`self-update` says "only available for standalone binaries"**
 

--- a/src/vaultctl/ai_detect.py
+++ b/src/vaultctl/ai_detect.py
@@ -45,12 +45,12 @@ def resolve_api_key(api_key_cmd: str) -> str:
     The API key is never logged or included in error messages.
     """
     if not api_key_cmd:
-        msg = "No api_key_cmd configured in .vaultctl.yml ai: section."
+        msg = "No api_key_cmd configured in .vaultctl/config.yml ai: section."
         raise AIDetectionError(msg)
     try:
-        # shell=True is accepted here: api_key_cmd comes from .vaultctl.yml which
-        # is a project-local config file under the operator's control (trust boundary).
-        # It is never derived from user input or vault content.
+        # shell=True is accepted here: api_key_cmd comes from .vaultctl/config.yml
+        # which is a project-local config file under the operator's control (trust
+        # boundary). It is never derived from user input or vault content.
         result = subprocess.run(  # nosec B602
             api_key_cmd,
             shell=True,
@@ -121,7 +121,7 @@ def _validate_endpoint(endpoint: str) -> None:
     for local services (Ollama, vLLM, etc.).
     """
     if not endpoint:
-        msg = "No AI endpoint configured in .vaultctl.yml ai: section."
+        msg = "No AI endpoint configured in .vaultctl/config.yml ai: section."
         raise AIDetectionError(msg)
     if endpoint.startswith("http://"):
         from urllib.parse import urlparse

--- a/src/vaultctl/cli.py
+++ b/src/vaultctl/cli.py
@@ -13,7 +13,7 @@ from typing import Any
 import click
 
 from .ai_detect import AIDetectionError, build_payload, call_ai, merge_results, resolve_api_key
-from .config import VaultConfig, find_config, load_config
+from .config import CONFIG_DIRNAME, CONFIG_FILENAME, CONFIG_RELPATH, VaultConfig, find_config, load_config
 from .detect import DetectionResult, detect_all, filter_by_confidence
 from .detection_ops import apply_detected_types
 from .keys import (
@@ -66,7 +66,11 @@ pass_ctx = click.make_pass_decorator(VaultContext)
 
 @click.group()
 @click.option(
-    "--config", "config_path", type=click.Path(exists=True), default=None, help="Path to .vaultctl.yml config file."
+    "--config",
+    "config_path",
+    type=click.Path(exists=True),
+    default=None,
+    help="Path to vaultctl config file (default: discover .vaultctl/config.yml).",
 )
 @click.option("--vault-file", type=click.Path(), default=None, help="Override vault file path.")
 @click.version_option(package_name="vaultctl")
@@ -79,8 +83,8 @@ def main(ctx: click.Context, config_path: str | None, vault_file: str | None) ->
         if ctx.invoked_subcommand in ("init", "self-update", "completion"):
             ctx.obj = VaultContext(VaultConfig())
             return
-        click.echo("Error: No .vaultctl.yml found.", err=True)
-        click.echo("Run 'vaultctl init' or create a .vaultctl.yml configuration.", err=True)
+        click.echo(f"Error: No {CONFIG_RELPATH} found.", err=True)
+        click.echo(f"Run 'vaultctl init' or create a {CONFIG_RELPATH} configuration.", err=True)
         sys.exit(1)
 
     config = load_config(cfg_path)
@@ -96,7 +100,8 @@ def main(ctx: click.Context, config_path: str | None, vault_file: str | None) ->
 @pass_ctx
 def init(_vctx: VaultContext, vault_file: str, keys_file: str, force: bool) -> None:
     """Initialize a new vaultctl project."""
-    config_path = Path.cwd() / ".vaultctl.yml"
+    config_dir = Path.cwd() / CONFIG_DIRNAME
+    config_path = config_dir / CONFIG_FILENAME
     if config_path.exists() and not force:
         click.echo(f"Error: {config_path} already exists. Use --force to overwrite.", err=True)
         sys.exit(1)
@@ -114,6 +119,7 @@ def init(_vctx: VaultContext, vault_file: str, keys_file: str, force: bool) -> N
             "file": "~/.ansible-vault-pass",
         },
     }
+    config_dir.mkdir(parents=True, exist_ok=True)
     config_path.write_text(
         yaml.dump(config_data, default_flow_style=False, sort_keys=False),
         encoding="utf-8",

--- a/src/vaultctl/config.py
+++ b/src/vaultctl/config.py
@@ -9,7 +9,9 @@ from pathlib import Path
 
 from .yaml_util import load_yaml
 
-CONFIG_FILENAME = ".vaultctl.yml"
+CONFIG_DIRNAME = ".vaultctl"
+CONFIG_FILENAME = "config.yml"
+CONFIG_RELPATH = f"{CONFIG_DIRNAME}/{CONFIG_FILENAME}"
 
 
 @dataclass
@@ -53,10 +55,10 @@ def _git_root(start: Path) -> Path | None:
 
 
 def find_config(start: Path | None = None) -> Path | None:
-    """Locate .vaultctl.yml using the standard search order.
+    """Locate the vaultctl config file using the standard search order.
 
     1. $VAULTCTL_CONFIG environment variable
-    2. .vaultctl.yml in *start* (default: cwd), then upwards to git root
+    2. .vaultctl/config.yml in *start* (default: cwd), then upwards to git root
     3. ~/.config/vaultctl/config.yml
     """
     env_path = os.environ.get("VAULTCTL_CONFIG")
@@ -72,7 +74,7 @@ def find_config(start: Path | None = None) -> Path | None:
 
     current = start.resolve()
     while True:
-        candidate = current / CONFIG_FILENAME
+        candidate = current / CONFIG_DIRNAME / CONFIG_FILENAME
         if candidate.is_file():
             return candidate
         if current == stop_at or current.parent == current:
@@ -86,10 +88,23 @@ def find_config(start: Path | None = None) -> Path | None:
     return None
 
 
+def _resolve_config_dir(config_path: Path) -> Path:
+    """Determine the directory that vault/keys paths in the config resolve against.
+
+    For the .vaultctl/config.yml convention this is the parent of the .vaultctl
+    directory (the project root). For an arbitrary --config override it is the
+    file's own directory.
+    """
+    parent = config_path.parent.resolve()
+    if parent.name == CONFIG_DIRNAME:
+        return parent.parent
+    return parent
+
+
 def load_config(path: Path) -> VaultConfig:
     """Load and validate a vaultctl config file."""
     raw = load_yaml(path)
-    config_dir = path.parent.resolve()
+    config_dir = _resolve_config_dir(path)
 
     pw_raw = raw.get("password", {}) or {}
     pw = PasswordConfig(

--- a/src/vaultctl/password.py
+++ b/src/vaultctl/password.py
@@ -43,9 +43,9 @@ def resolve_password(cfg: PasswordConfig) -> str:
     # 3. Command
     if cfg.cmd:
         try:
-            # shell=True is accepted here: the command comes from .vaultctl.yml which
-            # is a project-local config file under the operator's control (trust boundary).
-            # It is never derived from user input or vault content.
+            # shell=True is accepted here: the command comes from .vaultctl/config.yml
+            # which is a project-local config file under the operator's control (trust
+            # boundary). It is never derived from user input or vault content.
             result = subprocess.run(  # nosec B602
                 cfg.cmd,
                 shell=True,
@@ -60,5 +60,5 @@ def resolve_password(cfg: PasswordConfig) -> str:
     sources = "\n  ".join(tried) if tried else "(no sources configured)"
     raise PasswordError(
         f"Vault password not found. Tried:\n  {sources}\n\n"
-        "Configure a password source in .vaultctl.yml under 'password:'."
+        "Configure a password source in .vaultctl/config.yml under 'password:'."
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,7 @@ def keys_file(tmp_path):
 
 @pytest.fixture
 def config_file(tmp_path, vault_file, keys_file):
-    """Create a complete .vaultctl.yml config."""
+    """Create a complete .vaultctl/config.yml."""
     config = {
         "vault_file": str(vault_file),
         "keys_file": str(keys_file),
@@ -130,6 +130,8 @@ def config_file(tmp_path, vault_file, keys_file):
             "env": "VAULTCTL_TEST_PASS",
         },
     }
-    cf = tmp_path / ".vaultctl.yml"
+    config_dir = tmp_path / ".vaultctl"
+    config_dir.mkdir(exist_ok=True)
+    cf = config_dir / "config.yml"
     cf.write_text(yaml.dump(config, default_flow_style=False))
     return cf

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,10 +8,26 @@ import yaml
 from vaultctl.config import find_config, load_config
 
 
+def _write_config(root: Path, payload: str) -> Path:
+    """Write a config under the conventional .vaultctl/config.yml layout."""
+    config_dir = root / ".vaultctl"
+    config_dir.mkdir(exist_ok=True)
+    cfg = config_dir / "config.yml"
+    cfg.write_text(payload)
+    return cfg
+
+
 def test_find_config_in_cwd(tmp_path, monkeypatch):
-    cfg = tmp_path / ".vaultctl.yml"
-    cfg.write_text("vault_file: vault.yml\n")
+    cfg = _write_config(tmp_path, "vault_file: vault.yml\n")
     monkeypatch.chdir(tmp_path)
+    assert find_config() == cfg
+
+
+def test_find_config_walks_up_to_git_root(tmp_path, monkeypatch):
+    cfg = _write_config(tmp_path, "vault_file: vault.yml\n")
+    nested = tmp_path / "sub" / "deep"
+    nested.mkdir(parents=True)
+    monkeypatch.chdir(nested)
     assert find_config() == cfg
 
 
@@ -39,7 +55,7 @@ def test_find_config_user_global(tmp_path, monkeypatch):
         assert found == user_cfg
 
 
-def test_load_config_resolves_paths(tmp_path):
+def test_load_config_resolves_paths_relative_to_project_root(tmp_path):
     cfg_data = {
         "vault_file": "data/vault.yml",
         "keys_file": "data/keys.yml",
@@ -49,10 +65,12 @@ def test_load_config_resolves_paths(tmp_path):
             "cmd": "pass show vault",
         },
     }
-    cfg_path = tmp_path / ".vaultctl.yml"
-    cfg_path.write_text(yaml.dump(cfg_data))
+    cfg_path = _write_config(tmp_path, yaml.dump(cfg_data))
 
     config = load_config(cfg_path)
+    # Paths resolve from the project root (parent of .vaultctl/), not from
+    # inside .vaultctl/ — keeps vault.yml/vault-keys.yml at their natural
+    # location next to inventory data.
     assert config.vault_file == tmp_path / "data" / "vault.yml"
     assert config.keys_file == tmp_path / "data" / "keys.yml"
     assert config.password.env == "MY_PASS"
@@ -61,8 +79,15 @@ def test_load_config_resolves_paths(tmp_path):
 
 
 def test_load_config_defaults(tmp_path):
-    cfg_path = tmp_path / ".vaultctl.yml"
-    cfg_path.write_text("{}\n")
+    cfg_path = _write_config(tmp_path, "{}\n")
     config = load_config(cfg_path)
     assert config.vault_file == tmp_path / "vault.yml"
     assert config.keys_file == tmp_path / "vault-keys.yml"
+
+
+def test_load_config_explicit_path_resolves_from_file_dir(tmp_path):
+    """For --config <arbitrary-path>, paths resolve from the file's own dir."""
+    cfg_path = tmp_path / "standalone.yml"
+    cfg_path.write_text("vault_file: vault.yml\n")
+    config = load_config(cfg_path)
+    assert config.vault_file == tmp_path / "vault.yml"


### PR DESCRIPTION
## Summary

Replaces the root-level \`.vaultctl.yml\` with a project-local \`.vaultctl/\` directory. The directory is the future home for all vaultctl-managed metadata — config today, CUE schemas (#34) next.

**Before:**
\`\`\`
project-root/
├── .vaultctl.yml           # config at root
├── inventory/group_vars/all/
│   ├── vault.yml
│   └── vault-keys.yml
\`\`\`

**After:**
\`\`\`
project-root/
├── .vaultctl/
│   └── config.yml          # config in dedicated dir
├── inventory/group_vars/all/
│   ├── vault.yml           # unchanged
│   └── vault-keys.yml      # unchanged
\`\`\`

## What Changed

**Discovery (\`config.py\`):**
- \`find_config()\` now searches for \`.vaultctl/config.yml\` upwards from CWD to git root.
- New helper \`_resolve_config_dir()\` decides where vault/keys paths anchor: for the convention layout (\`.vaultctl/config.yml\`) it's the project root (parent of \`.vaultctl/\`); for an arbitrary \`--config <path>\` override it falls back to the file's own directory.
- This is the key design point: vault and keys files keep their natural Ansible location, the directory only holds vaultctl-specific metadata.

**Init (\`cli.py\`):**
- \`vaultctl init\` creates \`.vaultctl/\` and writes \`config.yml\` inside.
- Error messages and help text reference the new path.

**Documentation:**
- README's "Configuration" and "Troubleshooting" sections updated.
- CLAUDE.md's "Configuration discovery" design decision rewritten to explain the project-root anchoring rule.

**Tests:**
- \`test_config.py\` now writes configs under the convention layout via a small helper. Added two new cases: walking-up-from-deep-subdirectory discovery, and the arbitrary-path \`--config\` override behavior.
- \`conftest.py\` \`config_file\` fixture uses the new layout.

## Why Now

Prerequisite for #34 (CUE-based schema validation). The CUE schema files (\`vault.cue\`, \`vault.constraints.cue\`) need a home, and shipping them next to a root \`.vaultctl.yml\` only to move everything later would be churn. Doing the directory restructure first means #34 lands at the final paths from day one.

The \`ansible-vault\` documentation gap (just closed in #36) and the CUE work also forced a clearer articulation of vaultctl's "what's tool-config vs. what's data" model — this PR encodes that model in the file layout.

## Why No Backward Compatibility

vaultctl has no production users yet (confirmed at session start). A deprecation phase, parallel discovery, or migration command would all be unnecessary code paths. Cleanest possible cut keeps the architecture lean and the design intent visible.

Closes #37.
Refs #34.

## Test Plan

- [x] \`uv run ruff check\` clean
- [x] \`uv run mypy src/vaultctl\` strict — no issues
- [x] \`uv run bandit -r src/vaultctl\` — no new findings (10 pre-existing low/high-confidence items unchanged)
- [x] \`uv run pytest\` — 321 passed, 87.55% coverage (well above 70% threshold)
- [x] \`uv run pre-commit run\` on all changed files — green
- [ ] CI green