### PR TITLE
feat(schema): CUE-based validation and vaultctl validate command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
             --hidden-import=yaml \
             --hidden-import=importlib.metadata \
             --hidden-import=vaultctl.self_update \
+            --add-data "src/vaultctl/schemas:vaultctl/schemas" \
             --strip \
             --noconfirm \
             src/vaultctl/__main__.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ src/vaultctl/
 ├── password.py        # Password fallback chain (env -> file -> cmd)
 ├── vault.py           # ansible-vault subprocess wrapper
 ├── keys.py            # vault-keys.yml metadata CRUD + expiry check
+├── schema.py          # CUE schema validation (subprocess to cue binary)
+├── schemas/           # Bundled CUE schemas (config.cue, keys.cue, vault.cue)
 └── yaml_util.py       # YAML safe_load/dump helpers
 ```
 
@@ -98,6 +100,13 @@ src/vaultctl/
 - `vault.yml` is encrypted (actual secret values)
 - Expiry tracking via optional `expires` field (ISO 8601)
 
+**6. Schema validation via external `cue` binary:**
+- Same subprocess pattern as ansible-vault — no Python CUE binding is production-ready (April 2026)
+- Bundled schemas live in `src/vaultctl/schemas/` and are loaded via `importlib.resources`
+- User overrides land at `.vaultctl/<name>.cue` (e.g. `.vaultctl/vault.cue`)
+- Cross-file consistency check is pure Python — runs even when `cue` is missing
+- PyInstaller binary includes schemas via `--add-data` (see release.yml)
+
 ### CLI Commands
 
 | Command | Description |
@@ -111,6 +120,7 @@ src/vaultctl/
 | `vaultctl restore <key>` | Rollback to _previous |
 | `vaultctl edit` | Open vault in $EDITOR |
 | `vaultctl check` | Check expiring/expired keys |
+| `vaultctl validate` | Validate config/metadata/content against CUE schemas |
 
 ## Technology Stack
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ vaultctl check                        # which keys need attention?
 | `vaultctl edit` | Open vault in `$EDITOR` via `ansible-vault edit` |
 | `vaultctl check` | Report expired/expiring keys (`--json`, `--quiet`, `--warn-days N`) |
 | `vaultctl detect-types` | Auto-detect entry types (`--apply`, `--ai`, `--show-redacted`) |
+| `vaultctl validate` | Validate config, metadata, and vault content against CUE schemas |
 | `vaultctl self-update` | Update binary to latest release (standalone only) |
 
 All mutating commands support `--force` to skip confirmation prompts.
@@ -110,6 +111,35 @@ vault_keys:
 ```
 
 `vaultctl check` uses the `expires` field to flag expired or soon-to-expire credentials — exit code 1 for CI/cron integration.
+
+## Schema Validation
+
+`vaultctl validate` checks your project against CUE schemas — typo detection, type constraints, cross-file consistency. Useful as a CI gate or pre-commit hook.
+
+```bash
+vaultctl validate                # full check: config, metadata, vault, cross-consistency
+vaultctl validate --skip-content # skip vault content (no decryption needed)
+```
+
+**What it checks:**
+
+- `.vaultctl/config.yml` against the bundled `#Config` schema (catches typos like `pasword:`).
+- `vault-keys.yml` against the bundled `#KeysFile` schema (rejects unknown fields, invalid types like `bogusType`, malformed `expires` dates).
+- `vault.yml` content against the bundled `#VaultFile` schema (permissive by default — strings or structured objects).
+- Cross-file consistency: every key in `vault.yml` has metadata in `vault-keys.yml` and vice versa (`_previous` backup keys exempt).
+
+**Custom schemas:**
+
+Drop your own CUE schema next to the config to override the bundled defaults — keeps strict, project-specific rules close to the data.
+
+```
+.vaultctl/
+├── config.yml
+├── vault.cue              # overrides #VaultFile (e.g. require min password length)
+└── keys.cue               # overrides #KeysFile (e.g. require descriptions)
+```
+
+**Without `cue` installed:** schema checks are skipped with a warning; the cross-consistency check still runs.
 
 ## Type Detection
 

--- a/src/vaultctl/cli.py
+++ b/src/vaultctl/cli.py
@@ -27,10 +27,19 @@ from .keys import (
 )
 from .password import resolve_password
 from .redact import redact_vault_data
+from .schema import (
+    ValidationIssue,
+    cross_check_keys,
+    cue_available,
+    discover_user_schema,
+    validate_config_file,
+    validate_keys_file,
+    validate_vault_data,
+)
 from .search import MAX_PATTERN_LENGTH, SearchMatch, filter_keys, search_values
 from .types import detect_entry_type, get_entry_fields, get_field_value
 from .vault import VaultError, decrypt_vault, edit_vault, encrypt_vault
-from .yaml_util import clean_multiline_value, dump_yaml
+from .yaml_util import clean_multiline_value, dump_yaml, load_yaml
 
 
 def _format_value(value: Any) -> str:
@@ -959,3 +968,75 @@ def self_update_cmd(_vctx: VaultContext) -> None:
         click.echo(f"Updated to {new_version}.")
     else:
         click.echo("Already up to date.")
+
+
+def _format_issues(issues: list[ValidationIssue]) -> str:
+    return "\n".join(f"  [{i.file}] {i.message}" for i in issues)
+
+
+@main.command()
+@click.option(
+    "--skip-content",
+    is_flag=True,
+    default=False,
+    help="Skip vault content validation (only check config, metadata, and cross-consistency).",
+)
+@pass_ctx
+def validate(vctx: VaultContext, skip_content: bool) -> None:
+    """Validate config, metadata, and vault content against CUE schemas.
+
+    Checks performed:
+
+    - .vaultctl/config.yml against the bundled #Config schema
+    - vault-keys.yml against the bundled or project-local #KeysFile schema
+    - vault.yml content against the bundled or project-local #VaultFile schema (decrypts vault)
+    - cross-file consistency (every vault key has metadata, and vice versa)
+
+    The cross-consistency check runs in pure Python; the others require the
+    `cue` binary on PATH. When `cue` is missing, schema checks are skipped
+    with a warning and only the cross-check runs.
+    """
+    config_dir = vctx.config.config_dir
+    issues: list[ValidationIssue] = []
+
+    # 1. Cross-consistency check — always runs, no cue needed.
+    try:
+        vault_data = decrypt_vault(vctx.config.vault_file, vctx.password)
+    except VaultError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    # cross_check_keys needs the file-shape dict (with vault_keys wrapper),
+    # not the unwrapped form returned by load_keys.
+    raw_keys = load_yaml(vctx.config.keys_file) if vctx.config.keys_file.is_file() else {}
+    issues.extend(cross_check_keys(vault_data, raw_keys))
+
+    # 2. CUE-backed schema checks.
+    if not cue_available():
+        click.echo(
+            "Warning: 'cue' binary not found on PATH — schema validation skipped.",
+            err=True,
+        )
+        click.echo(
+            "Install: https://cuelang.org/docs/install/ — see README for details.",
+            err=True,
+        )
+    else:
+        # Config: only validate when discovered via the convention layout
+        # (config_dir/.vaultctl/config.yml). Arbitrary --config overrides skip.
+        config_path = config_dir / ".vaultctl" / "config.yml"
+        if config_path.is_file():
+            issues.extend(validate_config_file(config_path))
+
+        keys_override = discover_user_schema(config_dir, "keys")
+        issues.extend(validate_keys_file(vctx.config.keys_file, keys_override))
+
+        if not skip_content:
+            vault_override = discover_user_schema(config_dir, "vault")
+            issues.extend(validate_vault_data(vault_data, vault_override, label=str(vctx.config.vault_file)))
+
+    if issues:
+        click.echo(_format_issues(issues), err=True)
+        click.echo(f"\n{len(issues)} validation issue(s).", err=True)
+        sys.exit(1)
+    click.echo("All validations passed.")

--- a/src/vaultctl/schema.py
+++ b/src/vaultctl/schema.py
@@ -1,0 +1,154 @@
+"""CUE-based schema validation for vaultctl files.
+
+Calls the external `cue` binary via subprocess (same pattern as ansible-vault).
+Schema files are bundled with the package under `vaultctl/schemas/` and can be
+overridden by user-provided schemas under `.vaultctl/<name>.cue`.
+
+If the `cue` binary is not on PATH, schema validation is skipped gracefully —
+callers should treat `cue_available()` as a feature flag.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from importlib import resources
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class SchemaError(Exception):
+    """Raised when schema validation fails or cannot be performed."""
+
+
+@dataclass(frozen=True)
+class ValidationIssue:
+    """A single schema-violation finding."""
+
+    file: str
+    message: str
+
+
+def cue_available() -> bool:
+    """Return True if the `cue` binary is on PATH."""
+    return shutil.which("cue") is not None
+
+
+def bundled_schema(name: str) -> Path:
+    """Return the filesystem path of a bundled CUE schema.
+
+    Names are without extension: "config", "keys", "vault".
+    Falls back through importlib.resources to support installed wheels.
+    """
+    filename = f"{name}.cue"
+    schema_resource = resources.files("vaultctl.schemas").joinpath(filename)
+    # importlib.resources returns Traversable; for our use case (subprocess
+    # call to cue), we need a real filesystem path. Materialise if needed.
+    with resources.as_file(schema_resource) as p:
+        if p.is_file():
+            return Path(p)
+    msg = f"Bundled schema '{name}' not found."
+    raise SchemaError(msg)
+
+
+def discover_user_schema(config_dir: Path, name: str) -> Path | None:
+    """Look for a user-provided override schema in `.vaultctl/<name>.cue`.
+
+    `config_dir` is the project root (parent of `.vaultctl/`). Returns None
+    if no override exists.
+    """
+    candidate = config_dir / ".vaultctl" / f"{name}.cue"
+    return candidate if candidate.is_file() else None
+
+
+def _run_cue_vet(schema_path: Path, definition: str, data_path: Path) -> list[str]:
+    """Invoke `cue vet -d <definition> <schema> <data>` and return stderr lines."""
+    try:
+        result = subprocess.run(  # nosec B603
+            ["cue", "vet", "-d", definition, str(schema_path), str(data_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        msg = "cue binary not found on PATH."
+        raise SchemaError(msg) from exc
+
+    if result.returncode == 0:
+        return []
+    # cue prints diagnostics to stderr. Each line is a finding.
+    return [line for line in result.stderr.splitlines() if line.strip()]
+
+
+def validate_yaml_against_schema(
+    data: dict[str, Any], schema_path: Path, definition: str, label: str
+) -> list[ValidationIssue]:
+    """Validate an in-memory YAML structure against a CUE schema definition.
+
+    Writes the data to a temp YAML file and calls `cue vet`. The temp file is
+    removed on exit. Returns a (possibly empty) list of issues.
+    """
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yml", delete=False) as tf:
+        yaml.safe_dump(data, tf, default_flow_style=False, allow_unicode=True)
+        tmp_path = Path(tf.name)
+    try:
+        diagnostics = _run_cue_vet(schema_path, definition, tmp_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+    return [ValidationIssue(file=label, message=line) for line in diagnostics]
+
+
+def validate_config_file(config_path: Path) -> list[ValidationIssue]:
+    """Validate a .vaultctl/config.yml file against the bundled #Config schema."""
+    schema = bundled_schema("config")
+    diagnostics = _run_cue_vet(schema, "#Config", config_path)
+    return [ValidationIssue(file=str(config_path), message=line) for line in diagnostics]
+
+
+def validate_keys_file(keys_path: Path, override: Path | None = None) -> list[ValidationIssue]:
+    """Validate vault-keys.yml against the bundled or user-provided #KeysFile schema."""
+    schema = override or bundled_schema("keys")
+    diagnostics = _run_cue_vet(schema, "#KeysFile", keys_path)
+    return [ValidationIssue(file=str(keys_path), message=line) for line in diagnostics]
+
+
+def validate_vault_data(
+    vault_data: dict[str, Any], override: Path | None = None, label: str = "vault.yml"
+) -> list[ValidationIssue]:
+    """Validate decrypted vault content against the bundled or user-provided #VaultFile schema.
+
+    The data is written to a temp file because cue operates on filesystem inputs.
+    """
+    schema = override or bundled_schema("vault")
+    return validate_yaml_against_schema(vault_data, schema, "#VaultFile", label)
+
+
+def cross_check_keys(vault_data: dict[str, Any], keys_meta: dict[str, Any]) -> list[ValidationIssue]:
+    """Check that every key in vault.yml has metadata in vault-keys.yml and vice versa.
+
+    `_previous` backup keys are exempt from the metadata-required check.
+    Pure Python — does not require the cue binary.
+    """
+    vault_keys = {k for k in vault_data if not k.endswith("_previous")}
+    metadata_keys = set((keys_meta.get("vault_keys") or {}).keys())
+
+    issues: list[ValidationIssue] = []
+    for k in sorted(vault_keys - metadata_keys):
+        issues.append(
+            ValidationIssue(
+                file="cross-check",
+                message=f"key '{k}' has a value in vault.yml but no metadata in vault-keys.yml",
+            )
+        )
+    for k in sorted(metadata_keys - vault_keys):
+        issues.append(
+            ValidationIssue(
+                file="cross-check",
+                message=f"key '{k}' has metadata in vault-keys.yml but no value in vault.yml",
+            )
+        )
+    return issues

--- a/src/vaultctl/schemas/__init__.py
+++ b/src/vaultctl/schemas/__init__.py
@@ -1,0 +1,4 @@
+"""Bundled CUE schema files for vaultctl validation.
+
+Schemas are loaded by `vaultctl.schema` via importlib.resources.
+"""

--- a/src/vaultctl/schemas/config.cue
+++ b/src/vaultctl/schemas/config.cue
@@ -1,0 +1,28 @@
+// Schema for .vaultctl/config.yml
+//
+// Closed definitions — unknown top-level keys or typos are rejected.
+// All fields are optional because vaultctl ships sensible defaults; the schema
+// only constrains type and structure when fields are present.
+
+package vaultctl
+
+#PasswordConfig: {
+	env?:  string
+	file?: string
+	cmd?:  string
+}
+
+#AIConfig: {
+	endpoint?:          string
+	model?:             string
+	api_key_cmd?:       string
+	consent?:           bool
+	consent_timestamp?: string
+}
+
+#Config: {
+	vault_file?: string
+	keys_file?:  string
+	password?:   #PasswordConfig
+	ai?:         #AIConfig
+}

--- a/src/vaultctl/schemas/keys.cue
+++ b/src/vaultctl/schemas/keys.cue
@@ -1,0 +1,26 @@
+// Schema for vault-keys.yml metadata
+//
+// Closed key-metadata definition — typos in field names ("rotat", "expries")
+// are rejected. The known entry types match vaultctl/types.py.
+
+package vaultctl
+
+import "time"
+
+#KeyType: "usernamePassword" | "sshKey" | "certificate" | "secretText"
+
+#KeyMetadata: {
+	description?: string
+	type?:        #KeyType
+	rotate?:      string
+	// Accept either "YYYY-MM-DD" or full RFC 3339 timestamps.
+	expires?:    time.Format("2006-01-02") | time.Format(time.RFC3339)
+	consumers?:  [...string]
+	rotate_cmd?: string
+}
+
+#KeysFile: {
+	vault_keys: {
+		[string]: #KeyMetadata
+	}
+}

--- a/src/vaultctl/schemas/vault.cue
+++ b/src/vaultctl/schemas/vault.cue
@@ -1,0 +1,16 @@
+// Default permissive schema for vault.yml content
+//
+// Vault values can be plain strings or structured objects (typed entries).
+// Projects that want stricter rules — e.g. enforce minimum password length,
+// require specific subfields — override this by placing a custom .cue file
+// at .vaultctl/vault.cue with a top-level #VaultFile definition.
+
+package vaultctl
+
+#VaultEntry: string | {
+	...
+}
+
+#VaultFile: {
+	[string]: #VaultEntry
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -646,3 +646,104 @@ def test_set_file_cleans_whitespace(runner, cli_env, tmp_path):
     assert result.exit_code == 0
     for line in result.output.splitlines():
         assert line == line.rstrip(), f"Trailing whitespace found: {line!r}"
+
+
+# --- validate command ---
+
+
+def test_validate_reports_cross_check_mismatches(runner, cli_env):
+    """The shared fixtures intentionally have orphan keys on both sides — validate must detect them."""
+    result = runner.invoke(main, ["validate"])
+    assert result.exit_code == 1
+    # vault has untyped_creds without metadata
+    assert "untyped_creds" in result.output
+    # keys has expiring_key without value
+    assert "expiring_key" in result.output
+
+
+def test_validate_skip_content_still_runs_cross_check(runner, cli_env):
+    result = runner.invoke(main, ["validate", "--skip-content"])
+    assert result.exit_code == 1
+    assert "untyped_creds" in result.output
+
+
+def test_validate_warns_when_cue_missing(runner, cli_env, monkeypatch):
+    """When cue is unavailable, schema checks are skipped but cross-check still runs."""
+    monkeypatch.setattr("vaultctl.schema.shutil.which", lambda _: None)
+    result = runner.invoke(main, ["validate"])
+    # Cross-check still finds mismatches, so exit code is still 1
+    assert result.exit_code == 1
+    assert "cue" in result.output and "skipped" in result.output
+
+
+def test_validate_passes_on_aligned_vault(runner, tmp_path, monkeypatch):
+    """Build a small aligned vault/keys pair from scratch and verify validate exits 0."""
+    import os
+    import subprocess
+    import tempfile
+
+    import yaml as _yaml
+
+    project_root = tmp_path / "proj"
+    project_root.mkdir()
+    config_dir = project_root / ".vaultctl"
+    config_dir.mkdir()
+    vault_path = project_root / "vault.yml"
+    keys_path = project_root / "vault-keys.yml"
+
+    # Create plaintext data and encrypt with ansible-vault
+    plain = project_root / "plain.yml"
+    plain.write_text(_yaml.dump({"alpha": "value-a", "beta": "value-b"}))
+    pf_fd, pf_name = tempfile.mkstemp(suffix=".pass")
+    os.fchmod(pf_fd, 0o600)
+    try:
+        with os.fdopen(pf_fd, "w") as pf:
+            pf.write(PASS)
+        subprocess.run(
+            [
+                "ansible-vault",
+                "encrypt",
+                str(plain),
+                "--output",
+                str(vault_path),
+                "--vault-password-file",
+                pf_name,
+            ],
+            check=True,
+            capture_output=True,
+        )
+    finally:
+        from pathlib import Path as _Path
+
+        _Path(pf_name).unlink(missing_ok=True)
+    plain.unlink()
+
+    keys_path.write_text(
+        _yaml.dump(
+            {
+                "vault_keys": {
+                    "alpha": {"description": "A"},
+                    "beta": {"description": "B"},
+                }
+            }
+        )
+    )
+
+    config_path = config_dir / "config.yml"
+    config_path.write_text(
+        _yaml.dump(
+            {
+                "vault_file": str(vault_path),
+                "keys_file": str(keys_path),
+                "password": {"env": "VAULTCTL_TEST_PASS"},
+            }
+        )
+    )
+
+    monkeypatch.setenv("VAULTCTL_CONFIG", str(config_path))
+    monkeypatch.setenv("VAULTCTL_TEST_PASS", PASS)
+    monkeypatch.chdir(project_root)
+
+    result = runner.invoke(main, ["validate"])
+    assert result.exit_code == 0, result.output
+    assert "passed" in result.output

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,195 @@
+"""Tests for vaultctl.schema module."""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+import yaml
+from vaultctl.schema import (
+    bundled_schema,
+    cross_check_keys,
+    cue_available,
+    discover_user_schema,
+    validate_config_file,
+    validate_keys_file,
+    validate_vault_data,
+)
+
+requires_cue = pytest.mark.skipif(not shutil.which("cue"), reason="cue binary not installed")
+
+
+# --- module-level helpers (no cue required) ---
+
+
+def test_cue_available_returns_bool():
+    assert isinstance(cue_available(), bool)
+
+
+def test_bundled_schema_returns_paths_for_known_names():
+    for name in ("config", "keys", "vault"):
+        path = bundled_schema(name)
+        assert path.is_file()
+        assert path.suffix == ".cue"
+
+
+def test_bundled_schema_unknown_name_raises():
+    from vaultctl.schema import SchemaError
+
+    with pytest.raises(SchemaError):
+        bundled_schema("nonexistent")
+
+
+def test_discover_user_schema_returns_none_when_absent(tmp_path):
+    assert discover_user_schema(tmp_path, "vault") is None
+
+
+def test_discover_user_schema_returns_path_when_present(tmp_path):
+    cue_dir = tmp_path / ".vaultctl"
+    cue_dir.mkdir()
+    custom = cue_dir / "vault.cue"
+    custom.write_text("package vaultctl\n#VaultFile: { ... }\n")
+    assert discover_user_schema(tmp_path, "vault") == custom
+
+
+# --- cross_check_keys (pure Python, always runs) ---
+
+
+def test_cross_check_keys_no_issues_when_aligned():
+    vault_data = {"a": "1", "b": "2"}
+    keys_meta = {"vault_keys": {"a": {}, "b": {}}}
+    assert cross_check_keys(vault_data, keys_meta) == []
+
+
+def test_cross_check_keys_detects_value_without_metadata():
+    vault_data = {"a": "1", "orphan": "x"}
+    keys_meta = {"vault_keys": {"a": {}}}
+    issues = cross_check_keys(vault_data, keys_meta)
+    assert len(issues) == 1
+    assert "orphan" in issues[0].message
+    assert "no metadata" in issues[0].message
+
+
+def test_cross_check_keys_detects_metadata_without_value():
+    vault_data = {"a": "1"}
+    keys_meta = {"vault_keys": {"a": {}, "stale": {}}}
+    issues = cross_check_keys(vault_data, keys_meta)
+    assert len(issues) == 1
+    assert "stale" in issues[0].message
+    assert "no value" in issues[0].message
+
+
+def test_cross_check_keys_ignores_previous_backup_keys():
+    vault_data = {"a": "1", "a_previous": "old"}
+    keys_meta = {"vault_keys": {"a": {}}}
+    assert cross_check_keys(vault_data, keys_meta) == []
+
+
+def test_cross_check_keys_handles_missing_vault_keys_section():
+    vault_data = {"a": "1"}
+    keys_meta = {}
+    issues = cross_check_keys(vault_data, keys_meta)
+    assert len(issues) == 1
+    assert "a" in issues[0].message
+
+
+# --- CUE-backed validations (require cue binary) ---
+
+
+@requires_cue
+def test_validate_config_file_accepts_valid_config(tmp_path):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text(
+        yaml.dump(
+            {
+                "vault_file": "vault.yml",
+                "keys_file": "vault-keys.yml",
+                "password": {"env": "VAULT_PASS"},
+            }
+        )
+    )
+    assert validate_config_file(cfg) == []
+
+
+@requires_cue
+def test_validate_config_file_rejects_typo(tmp_path):
+    cfg = tmp_path / "config.yml"
+    cfg.write_text("vault_file: vault.yml\npasword:\n  env: X\n")
+    issues = validate_config_file(cfg)
+    assert any("pasword" in i.message for i in issues)
+
+
+@requires_cue
+def test_validate_config_file_rejects_wrong_type(tmp_path):
+    cfg = tmp_path / "config.yml"
+    # vault_file must be string, not int
+    cfg.write_text("vault_file: 123\n")
+    issues = validate_config_file(cfg)
+    assert len(issues) > 0
+
+
+@requires_cue
+def test_validate_keys_file_accepts_valid_metadata(tmp_path):
+    kf = tmp_path / "vault-keys.yml"
+    kf.write_text(
+        yaml.dump(
+            {
+                "vault_keys": {
+                    "api_token": {
+                        "description": "API token",
+                        "type": "secretText",
+                        "rotate": "365d",
+                        "expires": "2026-12-31",
+                    }
+                }
+            }
+        )
+    )
+    assert validate_keys_file(kf) == []
+
+
+@requires_cue
+def test_validate_keys_file_rejects_invalid_type(tmp_path):
+    kf = tmp_path / "vault-keys.yml"
+    kf.write_text(yaml.dump({"vault_keys": {"k": {"type": "bogusType"}}}))
+    issues = validate_keys_file(kf)
+    assert any("bogusType" in i.message or "conflicting values" in i.message for i in issues)
+
+
+@requires_cue
+def test_validate_keys_file_rejects_bad_date(tmp_path):
+    kf = tmp_path / "vault-keys.yml"
+    kf.write_text(yaml.dump({"vault_keys": {"k": {"expires": "tomorrow"}}}))
+    issues = validate_keys_file(kf)
+    assert len(issues) > 0
+
+
+@requires_cue
+def test_validate_vault_data_accepts_mixed_content():
+    data = {
+        "plain_string": "value",
+        "structured": {"username": "admin", "password": "secret"},
+    }
+    assert validate_vault_data(data) == []
+
+
+@requires_cue
+def test_validate_keys_file_with_user_override(tmp_path):
+    """User-provided schema overrides the bundled one."""
+    schema = tmp_path / "strict.cue"
+    schema.write_text("package vaultctl\n#KeysFile: {\n    vault_keys: [string]: { description: string }\n}\n")
+    kf = tmp_path / "vault-keys.yml"
+    # description missing → strict schema should fail
+    kf.write_text(yaml.dump({"vault_keys": {"k": {}}}))
+    issues = validate_keys_file(kf, override=schema)
+    assert len(issues) > 0
+
+
+# --- importlib.resources path resolution ---
+
+
+def test_bundled_schema_resolves_via_importlib_resources():
+    """Schemas must be discoverable through the package, not just via filesystem."""
+    path = bundled_schema("config")
+    # The file exists and is readable
+    assert path.read_text().startswith("// Schema")


### PR DESCRIPTION
## Summary

Adds CUE-based schema validation as a new feature class. \`vaultctl validate\` checks the project against bundled CUE schemas (typo detection, type and date constraints), runs cross-file consistency checks, and exits non-zero on any violation — usable as a CI gate or pre-commit hook.

The \`cue\` binary is shelled out to via subprocess, mirroring the existing pattern for \`ansible-vault\`. No native Python CUE binding is production-ready as of April 2026 (see issue body for the survey), so subprocess remains the realistic state of the art.

## What's New

**\`vaultctl validate\` command** — runs four classes of check:

1. **Config schema** — \`.vaultctl/config.yml\` against bundled \`#Config\` (catches \`pasword:\` style typos and wrong types).
2. **Metadata schema** — \`vault-keys.yml\` against bundled \`#KeysFile\` (rejects unknown fields, invalid \`type:\` values, malformed \`expires:\` dates; accepts both \`YYYY-MM-DD\` and full RFC 3339).
3. **Content schema** — \`vault.yml\` decrypted content against bundled \`#VaultFile\` (permissive default; opt out with \`--skip-content\`).
4. **Cross-consistency** — every key in \`vault.yml\` has matching metadata in \`vault-keys.yml\` and vice versa. Pure Python, runs even when \`cue\` is missing. \`_previous\` backup keys are exempt.

**User schema overrides:**

\`\`\`
.vaultctl/
├── config.yml
├── vault.cue              # replaces bundled #VaultFile (e.g. enforce min password length)
└── keys.cue               # replaces bundled #KeysFile (e.g. require descriptions)
\`\`\`

**Graceful fallback:** If \`cue\` is not on \`\$PATH\`, schema checks are skipped with a warning and a link to install instructions; the cross-consistency check still runs and exit code reflects its outcome.

**PyInstaller binary** now bundles \`schemas/*.cue\` via \`--add-data\` so the standalone binary can validate too.

## Why This Approach

**Subprocess to \`cue\`, not a Python binding:**
- \`pycue\` (PyPI, tebeka) — alpha, last release April 2024, marked inactive.
- \`cue-py\` (official, cue-lang/cue#3100) — opened April 2024, still no production release.
- \`philipdexter/pycue\` — minimal, abandoned.
- All three would wrap \`libcue\` (Go) via CFFI anyway. Direct subprocess is honest about the dependency and avoids CFFI complexity.

**Closed schema definitions** (\`#Config\`, \`#KeysFile\`) — they reject unknown top-level fields, which is the whole point: catching typos that \`load_config\` would silently ignore.

**Cross-consistency in Python, not CUE** — CUE *can* express this constraint, but expressing "for every key in dataset A there's a matching key in dataset B" via two separate file inputs is awkward in cue. Python is clearer here, and works without the binary.

**Bundled defaults, user overrides** — projects that don't need strict rules get value out of the box. Projects with stricter requirements (regex constraints on passwords, required \`description\` fields, etc.) drop their own \`.cue\` next to the config.

## Files

- \`src/vaultctl/schema.py\` — new module: subprocess wrapper, validation orchestration, importlib.resources for bundled schema discovery.
- \`src/vaultctl/schemas/{config,keys,vault}.cue\` — bundled CUE schemas.
- \`src/vaultctl/schemas/__init__.py\` — empty marker so the schemas dir is a package (resources discoverable).
- \`src/vaultctl/cli.py\` — \`vaultctl validate\` command.
- \`tests/test_schema.py\` — 19 tests with \`requires_cue\` skip marker.
- \`tests/test_cli.py\` — 4 CLI-level validate tests covering cross-check, skip-content, missing-cue, and aligned-vault paths.
- \`.github/workflows/release.yml\` — PyInstaller \`--add-data\` flag.
- \`README.md\`, \`CLAUDE.md\` — Schema Validation section, command table, architecture notes.

## What's NOT in this PR

The earlier discussion floated a \"schema lifecycle\" — \`vaultctl schema infer\` (generate from existing vault), \`vaultctl schema sync\` (auto-extend on new structure), interactive schema-update on \`set\`. That's a separate, larger feature class and gets its own issue once the validation foundation is in.

\`vaultctl import <yaml>\` (Use Case 3 from #34) is also deferred — it builds on the validation foundation but introduces its own design questions (merge semantics, conflict handling) better tackled separately.

Closes #34.

## Test Plan

- [x] \`uv run pytest\` — 344 passed (was 321 before this PR), 88% coverage.
- [x] \`uv run mypy src/vaultctl\` strict — clean.
- [x] \`uv run bandit -r src/vaultctl\` — no new findings.
- [x] \`uv run pre-commit run --all-files\` — green.
- [x] Manual: \`cue vet\` invocations against good and bad fixtures verified locally before integration.
- [ ] CI green.
- [ ] PyInstaller artifacts contain the schemas (will verify on next release tag).