### PR TITLE
docs(landscape): introduce vaultctl landscape with first ADR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Abstracted from:** Customer-specific `./vault` CLI (bash) and `credentials-ui` (FastAPI) into a generalized open-source tool.
 
+**Landschaften:** [vaultctl](docs/landscapes/vaultctl/LANDSCAPE.md) — design decision records and cross-cutting design notes live here.
+
 ## Build and Development Commands
 
 ```bash

--- a/docs/landscapes/vaultctl/LANDSCAPE.md
+++ b/docs/landscapes/vaultctl/LANDSCAPE.md
@@ -1,0 +1,45 @@
+# vaultctl Landscape
+
+vaultctl is a single-repo tool — there is no cross-repo landscape in the
+client-engagement sense. This directory exists because the tool has
+accumulated several cross-cutting design decisions worth documenting in
+a structured way, separate from CLAUDE.md (which describes the
+*current* state) and PR descriptions (which describe *changes*).
+
+The convention follows the Architecture Decision Records (ADR) pattern
+for `decisions/`. Subdirectories `patterns/` and `initiatives/` may be
+added later if needed.
+
+## Decisions
+
+| # | Title | Status |
+|---|-------|--------|
+| [0001](decisions/0001-schema-inference-via-python-walker.md) | Schema inference via Python walker, not `cue import` | Accepted |
+
+## Why a Landscape (Note on Convention)
+
+Per the global Claude Code guideline, tool repos typically don't have a
+landscape — landscapes group cross-repo work for client engagements.
+vaultctl is an exception by virtue of size and decision density: the
+choice to stay in Python over Go/Rust, the subprocess pattern for
+`ansible-vault` and `cue`, the project-local `.vaultctl/` layout, the
+schema inference approach — these are all decisions that future
+contributors (including the user's future self) will benefit from
+seeing in one place.
+
+If the convention should win, the directory can collapse to flat
+`docs/decisions/` later. The ADR files would migrate unchanged.
+
+## Backlog of Decisions to Backfill
+
+When relevant, these existing-but-undocumented decisions should be captured:
+
+- Python over Go/Rust for the implementation language (#36 era — covered
+  briefly in CLAUDE.md but not as an explicit ADR).
+- CUE validation via `cue` binary subprocess instead of native Python
+  binding (#34 — rationale lives in the issue body and PR #39 description).
+- Project-local `.vaultctl/` directory layout, no backward compatibility
+  with the legacy root-level `.vaultctl.yml` (#37/PR #38).
+
+These remain in their PR descriptions and CLAUDE.md sections for now —
+backfill is a P4 chore.

--- a/docs/landscapes/vaultctl/decisions/0001-schema-inference-via-python-walker.md
+++ b/docs/landscapes/vaultctl/decisions/0001-schema-inference-via-python-walker.md
@@ -1,0 +1,113 @@
+# 0001 — Schema inference via Python walker, not `cue import`
+
+- **Status:** Accepted
+- **Date:** 2026-04-27
+- **Decision in:** [PR #41](https://github.com/cdds-ab/vaultctl/pull/41)
+- **Related:** [#34](https://github.com/cdds-ab/vaultctl/issues/34), [#40](https://github.com/cdds-ab/vaultctl/issues/40)
+
+## Context
+
+`vaultctl schema infer` derives a CUE schema baseline from the current
+vault content. The decision was how to implement the YAML-to-CUE-schema
+transformation:
+
+1. **Option A — Use the `cue import` subcommand:** shell out to `cue import data.yml`,
+   then post-process the resulting CUE to replace concrete values with
+   their types.
+2. **Option B — Pure-Python walker:** walk the decrypted vault dict
+   directly and emit CUE syntax with types in place of values.
+
+The asymmetry is critical: `cue import` produces *concrete data in CUE
+syntax*, not a *schema*. A schema is what we want.
+
+```yaml
+# Input
+username: admin
+```
+
+```cue
+// `cue import` output (data, not schema)
+username: "admin"
+
+// What schema infer must produce
+username: string
+```
+
+So Option A still needs a value-to-type substitution pass. The bulk of
+the work is the substitution pass; running `cue import` first only adds
+a subprocess and a parse-and-rewrite step around it.
+
+## Decision
+
+Use Option B — pure-Python walker. Map Python types directly to CUE
+types as the dict is traversed.
+
+| Python type | CUE type emitted |
+|-------------|------------------|
+| `bool` (checked before `int`!) | `bool` |
+| `str` | `string` |
+| `int` | `int` |
+| `float` | `number` |
+| `None` | `null` |
+| `list[T]` (homogeneous) | `[...T]` |
+| `list` (mixed types) | `[...(T1 \| T2 \| ...)]` (sorted disjunction) |
+| `dict` | nested struct, recursively |
+| anything else | `_` (CUE top type) — surfaces unexpected shapes without crashing |
+
+`_previous` backup keys are excluded; field names with non-identifier
+characters get quoted.
+
+## Consequences
+
+**Positive:**
+
+- Self-contained: no extra `cue` subprocess per inference. Schema
+  generation works without the `cue` binary on `$PATH` (though
+  `validate` still needs it for the round-trip check).
+- Testable in pure Python: 11 unit tests run without any external
+  dependency. Round-trip tests then exercise the inferred schema
+  against `cue vet` to confirm the output is valid CUE.
+- Output is deterministic (sorted keys, stable formatting), suitable
+  for git-tracking and diffs.
+
+**Negative:**
+
+- We don't get CUE's parser for free. Edge cases like malformed YAML
+  surface as Python errors, not CUE errors. Acceptable — `decrypt_vault`
+  already raises before the walker runs, and YAML parse errors come
+  from `pyyaml`, which is the upstream of vault content anyway.
+- If we ever want to consume someone else's CUE input (e.g., a JSON
+  Schema imported via `cue import --jsonschema`) and turn that into
+  vaultctl's schema shape, we'd need a different code path. Not
+  currently a use case — only relevant if vaultctl ever ingests
+  external schema definitions.
+
+**Neutral:**
+
+- The walker emits closed schemas (`#VaultFile: { ... }` with no `...`
+  at the end). This is intentional: a closed inferred schema means
+  adding a new vault key without re-running `infer` (or extending the
+  schema by hand) makes `vaultctl validate` fail. That is the value —
+  structural changes become deliberate steps.
+
+## Alternatives Considered
+
+- **`cue import` + AST post-processing**: rejected. Adds a subprocess
+  hop and a CUE-to-CUE rewrite layer for no extra capability — the
+  type-substitution logic is the same effort either way.
+- **Native Python CUE binding**: rejected. No production-ready binding
+  exists as of April 2026 (`pycue` is alpha and inactive, official
+  `cue-py` not released — see [#34](https://github.com/cdds-ab/vaultctl/issues/34)
+  for the survey).
+- **JSON Schema generation, then `cue import --jsonschema`**: rejected.
+  Adds two indirections (Python→JSON Schema→CUE) for no benefit, and
+  loses information about CUE-specific constraints (regex, time formats)
+  that we may want to add later.
+
+## References
+
+- Implementation: `src/vaultctl/schema.py` — `infer_vault_schema()`,
+  `_render_type()`, `_quote_field()`.
+- Tests: `tests/test_schema.py` — `test_infer_*` (unit) and
+  round-trip tests with the `requires_cue` marker.
+- Discussion: PR #41 description and conversation history.


### PR DESCRIPTION
## Summary

Adds \`docs/landscapes/vaultctl/\` with a LANDSCAPE.md entry point and the first Architecture Decision Record (ADR): the rationale for using a pure-Python walker for schema inference rather than shelling out to \`cue import\`.

## Why a Landscape Here

Per global Claude Code guideline, tool repos typically don't have a landscape — landscapes group cross-repo work for client engagements (Zeiss, Aldi, ...). vaultctl is treated as a deliberate exception:

- Tool is at v1.x.
- Has accumulated several cross-cutting design choices that are scattered across PR descriptions and CLAUDE.md sections.
- A central, ADR-style location makes them discoverable for future contributors and the user's future self.

The LANDSCAPE.md flags this convention deviation explicitly and notes the directory can collapse to a flat \`docs/decisions/\` later without losing the ADR files.

## What's in the First ADR

\`0001-schema-inference-via-python-walker.md\` captures the design relationship behind the implementation choice in PR #41:

- **Why not \`cue import\`**: it produces concrete data in CUE syntax, not a schema. We'd still need a value-to-type substitution pass — which is the bulk of the work — so wrapping it around a subprocess hop adds complexity without removing any.
- **Why pure Python**: self-contained, no extra subprocess, testable without external binaries, deterministic output suitable for git-tracking.
- **Trade-off**: we don't get CUE's parser for free. Edge cases surface as Python errors. Acceptable because vault content comes from \`pyyaml\` upstream, which already raises before the walker runs.
- **Alternatives explicitly rejected**: \`cue import\` + AST post-processing, native Python CUE binding (none production-ready), JSON Schema indirection.

## Backfill Backlog (Not in This PR)

LANDSCAPE.md lists existing-but-undocumented decisions worth ADR'ing later:

- Python over Go/Rust (originated in our session discussion before #36).
- CUE validation via \`cue\` binary subprocess (rationale in #34/PR #39).
- Project-local \`.vaultctl/\` layout, no backward compat (#37/PR #38).

These remain in their PR bodies and CLAUDE.md sections for now — promoting them to ADRs is a P4 chore I can pick up incrementally.

## Files

- \`docs/landscapes/vaultctl/LANDSCAPE.md\` (new)
- \`docs/landscapes/vaultctl/decisions/0001-schema-inference-via-python-walker.md\` (new)
- \`CLAUDE.md\` (Landschaften-line referencing the new landscape, per global pattern)

Closes #42.
Refs #40, #41.

## Test Plan

- [x] Markdown renders cleanly (verified locally).
- [x] Cross-references work (\`#41\`, \`#34\`, \`#40\`).
- [ ] CI green.