### PR TITLE
fix(release): install uv inside semantic-release container

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,10 +167,12 @@ upload_to_release = true
 hvcs = "github"
 commit_message = "chore(release): bump version to {version}"
 # Sync uv.lock with the new version inside the release commit so the lockfile
-# never drifts behind pyproject.toml. The explicit git add is needed because
+# never drifts behind pyproject.toml. The semantic-release action runs in a
+# container without uv on PATH (exit 127 in the first attempt), hence the
+# explicit `pip install uv` first. The explicit `git add` is needed because
 # semantic-release only auto-stages files declared in version_variables /
 # version_toml.
-build_command = "uv lock && git add uv.lock"
+build_command = "pip install uv && uv lock && git add uv.lock"
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = [


### PR DESCRIPTION
## Summary

Fixes the followup-bug from #46: the \`build_command = \"uv lock && git add uv.lock\"\` shipped in PR #46 fails because \`python-semantic-release@v9.15.2\` runs in a Docker container that has Python+pip but **no uv on PATH**. Both release attempts after #46 and #47 merged returned exit 127 for that reason.

## Evidence

\`\`\`
CalledProcessError: Command '['bash', '-c',
'uv lock && git add uv.lock']' returned
non-zero exit status 127.
ERROR    [version.build_distributions] Build command failed with exit code 127
Build failed, aborting release
\`\`\`

The workflow's \"Add uv to PATH\" step puts \`~/.local/bin\` into \`\$GITHUB_PATH\`, but that environment doesn't propagate into the action's container. The container starts fresh with only what its image provides.

## Fix

Prepend \`pip install uv\` to the build_command:

\`\`\`toml
build_command = "pip install uv && uv lock && git add uv.lock"
\`\`\`

\`pip\` is available inside the action's container (it's a Python image). \`pip install uv\` is fast (single binary, ~3 seconds) and idempotent if uv is somehow already there. The build_command thereafter runs as designed and stages \`uv.lock\` into the release commit.

## Why Not a Separate Workflow Step?

Two reasons:

1. **Atomicity.** Inside \`build_command\`, the lock change lands in the *same* release commit as the version bump. A workflow step after the action would need either a force-push (forbidden on master) or a second commit per release.

2. **Reuse.** \`build_command\` is already configured for this purpose; we just need it to actually find \`uv\`.

## Followup

Until this PR merges and a release commit fires, master stays at 1.2.0 with all post-#39 work queued. The next successful release will be a single bump covering #46, #47, and this fix together.

Refs #44.