### PR TITLE
feat(schema): vaultctl schema sync drift detection (#40 phase 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ src/vaultctl/
 | `vaultctl check` | Check expiring/expired keys |
 | `vaultctl validate` | Validate config/metadata/content against CUE schemas |
 | `vaultctl schema infer` | Generate a CUE schema baseline from current vault content |
+| `vaultctl schema sync` | Detect drift between baseline and current vault |
 
 ## Technology Stack
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ vaultctl check                        # which keys need attention?
 | `vaultctl detect-types` | Auto-detect entry types (`--apply`, `--ai`, `--show-redacted`) |
 | `vaultctl validate` | Validate config, metadata, and vault content against CUE schemas |
 | `vaultctl schema infer` | Generate a CUE schema baseline from current vault content |
+| `vaultctl schema sync` | Detect drift between baseline and current vault (`--apply` to update) |
 | `vaultctl self-update` | Update binary to latest release (standalone only) |
 
 All mutating commands support `--force` to skip confirmation prompts.
@@ -149,6 +150,15 @@ vaultctl schema infer --force   # overwrites an existing baseline
 ```
 
 The generated baseline is a closed `#VaultFile` definition — adding a new key without re-running `infer` (or extending the schema by hand) makes `validate` fail. Hand-edited rules (regex constraints, value ranges, required descriptions) belong in a sibling `vault.constraints.cue` so subsequent `infer` runs don't trample them.
+
+**Detect drift between vault and baseline:**
+
+```bash
+vaultctl schema sync           # diff-only, exit 1 on drift — CI-friendly
+vaultctl schema sync --apply   # rewrite the baseline to match the vault
+```
+
+`schema sync` re-derives the schema from the current vault content and compares it to `.vaultctl/vault.cue`. Without `--apply` it prints a unified diff and exits non-zero; with `--apply` it rewrites the baseline. `vault.constraints.cue` is never touched — CUE merges it back in at validation time.
 
 **Without `cue` installed:** schema checks are skipped with a warning; the cross-consistency check still runs.
 

--- a/src/vaultctl/cli.py
+++ b/src/vaultctl/cli.py
@@ -29,10 +29,12 @@ from .password import resolve_password
 from .redact import redact_vault_data
 from .schema import (
     ValidationIssue,
+    compute_schema_drift,
     cross_check_keys,
     cue_available,
     discover_user_schema,
     infer_vault_schema,
+    render_schema_diff,
     validate_config_file,
     validate_keys_file,
     validate_vault_data,
@@ -1095,3 +1097,55 @@ def schema_infer(vctx: VaultContext, force: bool, output_path: str | None) -> No
             f"Tip: add project-specific constraints to {target.parent / 'vault.constraints.cue'} "
             "to keep them separate from the auto-generated baseline."
         )
+
+
+@schema_group.command("sync")
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Overwrite the baseline with the freshly inferred schema instead of just reporting drift.",
+)
+@pass_ctx
+def schema_sync(vctx: VaultContext, apply: bool) -> None:
+    """Detect drift between the vault content and the schema baseline.
+
+    Re-derives a schema from the current vault and compares it to
+    `.vaultctl/vault.cue`. Without `--apply`, prints a unified diff and exits
+    non-zero on drift — useful as a CI gate. With `--apply`, overwrites the
+    baseline with the fresh inference (existing hand-edited rules in
+    `vault.constraints.cue` are untouched, since CUE merges them at validation
+    time).
+
+    Exit codes:
+      0 — no drift, baseline matches vault.
+      1 — drift detected (or fresh schema written with --apply).
+      2 — no baseline exists yet; run `vaultctl schema infer` first.
+    """
+    baseline = vctx.config.config_dir / ".vaultctl" / "vault.cue"
+    if not baseline.is_file():
+        click.echo(
+            f"Error: no baseline at {baseline}. Run `vaultctl schema infer` to create one.",
+            err=True,
+        )
+        sys.exit(2)
+
+    try:
+        vault_data = decrypt_vault(vctx.config.vault_file, vctx.password)
+    except VaultError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
+
+    drifted, current, fresh = compute_schema_drift(vault_data, baseline)
+    if not drifted:
+        click.echo(f"No drift. {baseline} matches the current vault.")
+        return
+
+    if apply:
+        baseline.write_text(fresh, encoding="utf-8")
+        click.echo(f"Updated {baseline} to match current vault.")
+        sys.exit(1)
+
+    click.echo(render_schema_diff(current, fresh, str(baseline)))
+    click.echo(f"\nDrift detected. Run `vaultctl schema sync --apply` to update {baseline}.", err=True)
+    sys.exit(1)

--- a/src/vaultctl/schema.py
+++ b/src/vaultctl/schema.py
@@ -225,6 +225,44 @@ def infer_vault_schema(vault_data: dict[str, Any]) -> str:
     return f"{header}\n{package}\n{body}"
 
 
+def compute_schema_drift(vault_data: dict[str, Any], baseline_path: Path) -> tuple[bool, str, str]:
+    """Compare the inferred schema for `vault_data` against an existing baseline file.
+
+    Returns (drifted, current_baseline_text, fresh_schema_text).
+
+    The auto-generated header is stripped from both sides before comparison so
+    timestamp / wording changes don't trigger false positives. The header is
+    restored when the caller writes the fresh schema back.
+    """
+    fresh = infer_vault_schema(vault_data)
+    if not baseline_path.is_file():
+        return True, "", fresh
+    current = baseline_path.read_text(encoding="utf-8")
+
+    drifted = _strip_header(current).strip() != _strip_header(fresh).strip()
+    return drifted, current, fresh
+
+
+def render_schema_diff(current: str, fresh: str, baseline_label: str) -> str:
+    """Render a unified diff between current baseline and a freshly inferred schema."""
+    import difflib
+
+    diff_lines = difflib.unified_diff(
+        current.splitlines(keepends=True),
+        fresh.splitlines(keepends=True),
+        fromfile=f"{baseline_label} (current)",
+        tofile=f"{baseline_label} (inferred)",
+        lineterm="",
+    )
+    return "".join(diff_lines)
+
+
+def _strip_header(text: str) -> str:
+    """Remove the auto-generated header comment block so it doesn't dominate diffs."""
+    lines = text.splitlines()
+    return "\n".join(line for line in lines if not line.startswith("//"))
+
+
 def cross_check_keys(vault_data: dict[str, Any], keys_meta: dict[str, Any]) -> list[ValidationIssue]:
     """Check that every key in vault.yml has metadata in vault-keys.yml and vice versa.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -786,3 +786,72 @@ def test_schema_infer_overwrites_with_force(runner, cli_env, tmp_path):
     result = runner.invoke(main, ["schema", "infer", "--output", str(output), "--force"])
     assert result.exit_code == 0, result.output
     assert "AUTO-GENERATED" in output.read_text()
+
+
+# --- schema sync command ---
+
+
+def _write_baseline_for_cli_env(cli_env_path):
+    """Write a baseline matching the cli_env vault into .vaultctl/vault.cue."""
+    from pathlib import Path as _Path
+
+    import yaml as _yaml
+
+    config_data = _yaml.safe_load(_Path(cli_env_path).read_text())
+    # The cli_env config_file points at absolute paths for vault and keys.
+    # config_dir for `.vaultctl/vault.cue` is the parent of the .vaultctl dir,
+    # which is tmp_path.
+    project_root = _Path(cli_env_path).parent.parent
+    baseline_dir = project_root / ".vaultctl"
+    baseline_dir.mkdir(parents=True, exist_ok=True)
+    return baseline_dir / "vault.cue", project_root, config_data
+
+
+def test_schema_sync_no_drift_after_infer(runner, cli_env):
+    """Right after `schema infer`, sync should report no drift."""
+    infer = runner.invoke(main, ["schema", "infer"])
+    assert infer.exit_code == 0, infer.output
+    result = runner.invoke(main, ["schema", "sync"])
+    assert result.exit_code == 0, result.output
+    assert "No drift" in result.output
+
+
+def test_schema_sync_missing_baseline_exits_2(runner, cli_env):
+    """Without a baseline, sync exits with code 2 and a clear hint."""
+    result = runner.invoke(main, ["schema", "sync"])
+    assert result.exit_code == 2
+    assert "no baseline" in result.output.lower()
+    assert "schema infer" in result.output
+
+
+def test_schema_sync_detects_drift_from_stale_baseline(runner, cli_env, tmp_path):
+    """A baseline missing a key should be detected as drift."""
+    # Write an intentionally incomplete baseline
+    project_root = tmp_path
+    baseline_dir = project_root / ".vaultctl"
+    baseline_dir.mkdir(exist_ok=True)
+    baseline = baseline_dir / "vault.cue"
+    baseline.write_text("package vaultctl\n\n#VaultFile: {\n\tonly_one_key: string\n}\n")
+
+    result = runner.invoke(main, ["schema", "sync"])
+    assert result.exit_code == 1
+    # The diff should mention the keys that are present in the vault fixture
+    # but missing from the stale baseline.
+    assert "test_key" in result.output or "db_creds" in result.output
+    assert "Drift detected" in result.output
+
+
+def test_schema_sync_apply_updates_baseline(runner, cli_env, tmp_path):
+    """`--apply` rewrites the baseline to match the vault."""
+    baseline = tmp_path / ".vaultctl" / "vault.cue"
+    baseline.parent.mkdir(exist_ok=True)
+    baseline.write_text("package vaultctl\n\n#VaultFile: {\n\tonly_one_key: string\n}\n")
+
+    result = runner.invoke(main, ["schema", "sync", "--apply"])
+    assert result.exit_code == 1  # exit 1 even on apply, indicates drift was present
+    assert "Updated" in result.output
+
+    # Re-running should now find no drift
+    follow_up = runner.invoke(main, ["schema", "sync"])
+    assert follow_up.exit_code == 0, follow_up.output
+    assert "No drift" in follow_up.output

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,10 +8,12 @@ import pytest
 import yaml
 from vaultctl.schema import (
     bundled_schema,
+    compute_schema_drift,
     cross_check_keys,
     cue_available,
     discover_user_schema,
     infer_vault_schema,
+    render_schema_diff,
     validate_config_file,
     validate_keys_file,
     validate_vault_data,
@@ -303,3 +305,79 @@ def test_infer_merges_with_user_constraints_file(tmp_path):
     # in the same directory automatically when they share the package.
     issues = validate_vault_data(data, override=baseline)
     assert any("password" in i.message for i in issues), "expected merged constraint to reject the short password"
+
+
+# --- schema drift detection (pure Python, no cue required) ---
+
+
+def test_drift_detected_when_baseline_missing(tmp_path):
+    drifted, current, fresh = compute_schema_drift({"a": "x"}, tmp_path / "missing.cue")
+    assert drifted is True
+    assert current == ""
+    assert "a: string" in fresh
+
+
+def test_no_drift_when_baseline_matches(tmp_path):
+    data = {"token": "secret", "creds": {"username": "u", "password": "p"}}
+    baseline = tmp_path / "vault.cue"
+    baseline.write_text(infer_vault_schema(data))
+    drifted, _, _ = compute_schema_drift(data, baseline)
+    assert drifted is False
+
+
+def test_drift_detected_when_key_added(tmp_path):
+    baseline = tmp_path / "vault.cue"
+    baseline.write_text(infer_vault_schema({"a": "x"}))
+    drifted, _, fresh = compute_schema_drift({"a": "x", "new_key": 42}, baseline)
+    assert drifted is True
+    assert "new_key: int" in fresh
+
+
+def test_drift_detected_when_key_removed(tmp_path):
+    baseline = tmp_path / "vault.cue"
+    baseline.write_text(infer_vault_schema({"a": "x", "obsolete": "y"}))
+    drifted, _, fresh = compute_schema_drift({"a": "x"}, baseline)
+    assert drifted is True
+    assert "obsolete" not in fresh
+
+
+def test_drift_detected_when_type_changes(tmp_path):
+    baseline = tmp_path / "vault.cue"
+    baseline.write_text(infer_vault_schema({"port": "5432"}))  # was string
+    drifted, _, fresh = compute_schema_drift({"port": 5432}, baseline)  # now int
+    assert drifted is True
+    assert "port: int" in fresh
+
+
+def test_drift_ignores_header_changes(tmp_path):
+    """Comment-only differences in the header should not trigger drift."""
+    baseline = tmp_path / "vault.cue"
+    baseline.write_text(
+        "// Some other auto-generation header text.\n"
+        "// That differs from the current INFER_HEADER.\n"
+        "\npackage vaultctl\n\n#VaultFile: {\n\ta: string\n}\n"
+    )
+    drifted, _, _ = compute_schema_drift({"a": "x"}, baseline)
+    assert drifted is False
+
+
+def test_drift_ignores_previous_backup_keys(tmp_path):
+    """_previous keys aren't part of the schema, so they don't cause drift."""
+    baseline = tmp_path / "vault.cue"
+    baseline.write_text(infer_vault_schema({"live": "x"}))
+    drifted, _, _ = compute_schema_drift({"live": "x", "live_previous": "old"}, baseline)
+    assert drifted is False
+
+
+def test_render_schema_diff_produces_unified_diff():
+    current = "package vaultctl\n\n#VaultFile: {\n\ta: string\n}\n"
+    fresh = "package vaultctl\n\n#VaultFile: {\n\ta: string\n\tb: int\n}\n"
+    diff = render_schema_diff(current, fresh, "vault.cue")
+    assert "vault.cue (current)" in diff
+    assert "vault.cue (inferred)" in diff
+    assert "+\tb: int" in diff
+
+
+def test_render_schema_diff_empty_when_identical():
+    text = "package vaultctl\n\n#VaultFile: {}\n"
+    assert render_schema_diff(text, text, "vault.cue") == ""


### PR DESCRIPTION
## Summary

Phase 2 of #40: \`vaultctl schema sync\` detects drift between the vault content and the \`.vaultctl/vault.cue\` baseline. Builds directly on the inference foundation that landed in #41/v1.2.0 — same walker, just compared against an existing baseline instead of written fresh.

## New Command

\`\`\`bash
vaultctl schema sync           # diff-only, exit 1 on drift — CI-friendly
vaultctl schema sync --apply   # rewrite the baseline to match the vault
\`\`\`

Exit codes:
- \`0\` — no drift, baseline matches.
- \`1\` — drift detected, or fresh schema written with \`--apply\`.
- \`2\` — no baseline exists; suggests \`vaultctl schema infer\` to create one.

Sample output on drift:

\`\`\`diff
--- /home/.../vault.cue (current)
+++ /home/.../vault.cue (inferred)
@@ -2,5 +2,6 @@

 #VaultFile: {
        existing_key: string
+       new_key: int
 }
 
Drift detected. Run \`vaultctl schema sync --apply\` to update /home/.../vault.cue.
\`\`\`

## Implementation

- \`compute_schema_drift()\` — pure-Python helper that re-infers the schema from the current vault, strips both sides' auto-generated header comments (so wording changes in the header don't trigger false positives), and returns \`(drifted, current_text, fresh_text)\`.
- \`render_schema_diff()\` — thin wrapper over \`difflib.unified_diff\` with stable filename labels for readable output.
- \`@schema_group.command(\"sync\")\` — orchestrates the three exit-code paths.

\`vault.constraints.cue\` is **never** touched. CUE merges it back in at validation time, so hand-edited rules (regex constraints, value ranges) survive both \`infer\` and \`sync\`.

## Test Coverage

13 new tests:

- 9 pure-Python unit tests (no cue binary required) covering missing baseline, key add/remove, type change, header-only differences ignored, \`_previous\` backup keys excluded from drift, diff rendering on add/identical.
- 4 CLI integration tests covering: no-drift after \`schema infer\`, missing-baseline exit-2, drift detection from a stale baseline, \`--apply\` round-trip (drift → apply → no drift).

Total tests: 360 → 373. Coverage stable at 88%.

## Followup

Phase 3 of #40 — schema-aware \`set\` (interactive prompt to extend the baseline when \`set\` introduces a new structure). That's UX work on top of what's now in place; ships as a separate PR.

Refs #40.